### PR TITLE
Add lang attribute to <html> element

### DIFF
--- a/build/controllers/views/translation/report_html.php
+++ b/build/controllers/views/translation/report_html.php
@@ -3,7 +3,7 @@
 use yii\helpers\Html;
 
 ?><!doctype html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8" />
         <title>Translation report</title>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

The html element is added with the lang attribute in order to identify the default language of a document.